### PR TITLE
CI: Add lint job and update setup-uv to v6.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,6 @@ on:
     # relevant branches and tags. Other branches can be checked via PRs.
     # branches: [main]
     tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
-    branches:
-      - 35-update-ci-pipeline
   pull_request:  # Run in every PR
   workflow_dispatch:  # Allow manually triggering the workflow
 


### PR DESCRIPTION
### Summary

This PR improves the CI workflow in two key ways:

1. **Adds a dedicated lint job** that runs before tests.  
   - If linting fails, tests are blocked, ensuring only clean code proceeds through CI.
   - Runs `ruff` and `mypy` checks.

2. **Updates `astral-sh/setup-uv` action** from `v3` to `v6.7.0`.  
   - Enables caching improvements and better Python environment setup.

### Changes

- Added `lint` job in `.github/workflows/ci.yml`.
- Updated `uses: astral-sh/setup-uv@v6.7.0` in all relevant jobs.
- `tests` job now depends on `lint` (`needs: lint`).

### Linked Issue

Fixes #35 
