### PR TITLE
Fix dangling subprocess

### DIFF
--- a/src/kanban_tui/cli/mcp_commands.py
+++ b/src/kanban_tui/cli/mcp_commands.py
@@ -1,4 +1,6 @@
 import asyncio
+import signal
+import sys
 
 import click
 
@@ -51,12 +53,52 @@ def mcp(app: KanbanTui, ctx, start_server: bool):
     )
     mcp_server = CommandMCPServer(commands=[query])
 
-    async def run_stdio():
-        async with stdio_server() as (read_stream, write_stream):
-            await mcp_server.server.run(
-                read_stream,
-                write_stream,
-                mcp_server.server.create_initialization_options(),
-            )
+    # Create a shutdown event for graceful cleanup
+    shutdown_event = asyncio.Event()
 
-    asyncio.run(run_stdio())
+    def signal_handler(sig, frame):
+        """Handle shutdown signals gracefully"""
+        shutdown_event.set()
+
+    # Register signal handlers
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    async def run_stdio():
+        try:
+            async with stdio_server() as (read_stream, write_stream):
+                server_task = asyncio.create_task(
+                    mcp_server.server.run(
+                        read_stream,
+                        write_stream,
+                        mcp_server.server.create_initialization_options(),
+                    )
+                )
+
+                shutdown_task = asyncio.create_task(shutdown_event.wait())
+
+                # Wait for either the server to complete or shutdown signal
+                done, pending = await asyncio.wait(
+                    {server_task, shutdown_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Cancel any pending tasks
+                for task in pending:
+                    task.cancel()
+                    try:
+                        await task
+                    except asyncio.CancelledError:
+                        pass
+
+        except Exception as e:
+            print_to_console(f"[red]MCP server error: {e}[/]")
+            sys.exit(1)
+        finally:
+            pass
+
+    try:
+        asyncio.run(run_stdio())
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sys.exit(0)


### PR DESCRIPTION
Run MCP in an asyncio task with another task, which listens to SIGINT | SIGTERM signals to close everything properly