### PR TITLE
Fix double demo task creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Added column mapping per `jql`/`jira board`
 - Added ability to transition tasks between columns in `jira` backend
 
+### Fixed
+- Demo running with `--web`flag now only creates tasks once
+
 ## v0.17.1
 ### Fixed
 - Fixed scroll flickering when selecting through tasks, by disabling the animation when using `scroll_visible`

--- a/src/kanban_tui/cli/demo_commands.py
+++ b/src/kanban_tui/cli/demo_commands.py
@@ -21,9 +21,6 @@ def demo(app: KanbanTui, clean: bool, keep: bool, web: bool):
     """
     Starts a demo app with temporary database and config
     """
-    if not clean:
-        create_demo_tasks(app)
-
     if web:
         try:
             from textual_serve.server import Server
@@ -40,6 +37,9 @@ def demo(app: KanbanTui, clean: bool, keep: bool, web: bool):
         server = Server(command)
         server.serve()
     else:
+        if not clean:
+            create_demo_tasks(app)
+
         app.run()
 
     if not keep:


### PR DESCRIPTION
Since the --web flag makes textual serve run the demo command anyways, we can move the demo task creation to that branch Closes #107