### PR TITLE
Fix columns_in_view updating correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Fixed use of Select.BLANK and replaced with Select.NULL,
 necessary due to change in [textual v0.8.0](https://github.com/Textualize/textual/releases/tag/v8.0.0)
+- Fixed correct update of `boards.columns_in_view` if columns where altered
 
 ## v0.19.1
 ### Fixed

--- a/src/kanban_tui/widgets/settings_widgets.py
+++ b/src/kanban_tui/widgets/settings_widgets.py
@@ -99,7 +99,8 @@ class BoardColumnsInView(Horizontal):
     def update_config(self, event: Select.Changed):
         self.app.config.set_columns_in_view(event.select.value)
 
-    def set_initial_select_value(self):
+    @work()
+    async def set_initial_select_value(self):
         select = self.query_one(Select)
         amount_cols = len(self.app.column_list)
         if self.app.config.board.columns_in_view > amount_cols:
@@ -458,6 +459,7 @@ class ColumnSelector(ListView):
         await self.app.screen.query_one(StatusColumnSelector).recompose()
         self.app.screen.query_one(StatusColumnSelector).get_select_widget_values()
         await self.app.screen.query_one(BoardColumnsInView).recompose()
+        self.app.screen.query_one(BoardColumnsInView).set_initial_select_value()
 
     def watch_amount_visible(self):
         self.border_title = f"columns.visible  [cyan]{self.amount_visible} / {len(self.app.column_list)}[/]"

--- a/tests/app_tests/test_settings_screen.py
+++ b/tests/app_tests/test_settings_screen.py
@@ -366,6 +366,32 @@ async def test_column_rename(test_app: KanbanTui):
         assert pilot.app.screen.query_one("#column_1").title == "New Name!"
 
 
+# Test for https://github.com/Zaloog/kanban-tui/issues/113
+async def test_column_rename_columns_in_view_bug(test_app: KanbanTui):
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        await pilot.press("ctrl+l")
+        await pilot.pause()
+        # focus selector
+        # await pilot.press("shift+tab")
+        pilot.app.screen.query_exactly_one(ColumnSelector).focus()
+        await pilot.pause()
+        assert isinstance(test_app.focused, ColumnSelector)
+
+        # Navigate to First ColumnListItem
+        await pilot.press("j")
+        assert test_app.focused.highlighted_child.column.name == "Ready"
+
+        # Rename
+        await pilot.press("r")
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
+
+        await pilot.press(*"New Name!")
+        await pilot.click("#btn_continue")
+        await pilot.pause()
+        assert pilot.app.focused.highlighted_child.column.name == "New Name!"
+        assert test_app.screen.query_exactly_one("#select_columns_in_view").value == 3
+
+
 async def test_setting_shortcuts(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         await pilot.press("ctrl+l")


### PR DESCRIPTION
When editing/deleting columns, the `boards.columns_in_view` setting was not properly updating to the adjusted value

- called the update function in a worker to ensure its called after the widget is loaded
- also added a test
closes #113 