### PR TITLE
feat: add focus-revealed task metadata setting

### DIFF
--- a/src/kanban_tui/assets/style.tcss
+++ b/src/kanban_tui/assets/style.tcss
@@ -72,7 +72,7 @@ Column VerticalScroll {
 TaskCard {
   width: 1fr;
   height: auto;
-  min-height: 5;
+  min-height: 3;
   margin: 0 0 1 0;
   border: tall transparent;
   transition: height 200ms linear;
@@ -556,6 +556,17 @@ DataBasePathInput{
 
 }
 TaskAlwaysExpandedSwitch{
+  height:auto;
+  width:1fr;
+  Label{
+    width:1fr;
+    padding: 1 0 0 1;
+  }
+  Switch {
+      width:1fr;
+  }
+}
+TaskMetadataAlwaysExpandedSwitch{
   height:auto;
   width:1fr;
   Label{

--- a/src/kanban_tui/config.py
+++ b/src/kanban_tui/config.py
@@ -39,6 +39,7 @@ class BoardSettings(BaseModel):
 class TaskSettings(BaseModel):
     default_color: str = Field(default="#004578")
     always_expanded: bool = Field(default=False)
+    metadata_always_expanded: bool = Field(default=True)
     movement_mode: MovementModes = Field(default=MovementModes("adjacent"))
 
 
@@ -92,6 +93,10 @@ class Settings(BaseSettings):
 
     def set_task_always_expanded(self, new_value: bool) -> None:
         self.task.always_expanded = new_value
+        self.save()
+
+    def set_task_metadata_always_expanded(self, new_value: bool) -> None:
+        self.task.metadata_always_expanded = new_value
         self.save()
 
     def set_task_default_color(self, new_color: str) -> None:

--- a/src/kanban_tui/screens/settings_screen.py
+++ b/src/kanban_tui/screens/settings_screen.py
@@ -25,6 +25,7 @@ class SettingsScreen(Screen):
         yield Jumper(
             ids_to_keys={
                 "switch_expand_tasks": "e",
+                "switch_expand_metadata": "m",
                 "select_columns_in_view": "b",
                 "task_color_preview": "g",
                 "select_movement_mode": "n",

--- a/src/kanban_tui/widgets/settings_widgets.py
+++ b/src/kanban_tui/widgets/settings_widgets.py
@@ -129,6 +129,26 @@ class TaskAlwaysExpandedSwitch(Horizontal):
         self.app.config.set_task_always_expanded(new_value=event.value)
 
 
+class TaskMetadataAlwaysExpandedSwitch(Horizontal):
+    app: "KanbanTui"
+
+    def on_mount(self):
+        self.border_title = "task.metadata_always_expanded"
+
+    def compose(self) -> Iterable[Widget]:
+        yield Label("Always Show Metadata")
+        metadata_switch = Switch(
+            value=self.app.config.task.metadata_always_expanded,
+            id="switch_expand_metadata",
+        )
+        metadata_switch.jump_mode = "focus"
+        yield metadata_switch
+
+    @on(Switch.Changed)
+    def update_config(self, event: Switch.Changed):
+        self.app.config.set_task_metadata_always_expanded(new_value=event.value)
+
+
 class TaskDefaultColorSelector(Horizontal):
     app: "KanbanTui"
 
@@ -639,9 +659,11 @@ class SettingsView(Vertical):
         yield DataBasePathInput(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
             yield TaskAlwaysExpandedSwitch(classes="setting-block")
-            yield TaskMovementSelector(classes="setting-block")
+            yield TaskMetadataAlwaysExpandedSwitch(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
+            yield TaskMovementSelector(classes="setting-block")
             yield TaskDefaultColorSelector(classes="setting-block")
+        with Horizontal(classes="setting-horizontal"):
             yield BoardColumnsInView(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
             yield StatusColumnSelector(classes="setting-block")

--- a/src/kanban_tui/widgets/task_card.py
+++ b/src/kanban_tui/widgets/task_card.py
@@ -117,7 +117,10 @@ class TaskCard(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Label(self.task_.title, classes="label-title")
-        yield Label(self.get_compact_metadata_str(), classes="label-metadata")
+        self.metadata_label = Label(
+            self.get_compact_metadata_str(), classes="label-metadata"
+        )
+        yield self.metadata_label
         self.description = Markdown(
             markdown=self.task_.description,
         )
@@ -135,6 +138,7 @@ class TaskCard(Vertical):
             self.styles.background = self.app.config.task.default_color
         self.description.styles.background = self.styles.background.darken(0.2)  # type: ignore
         self.description.display = self.app.config.task.always_expanded
+        self.metadata_label.display = self.app.config.task.metadata_always_expanded
 
     def on_focus(self) -> None:
         self.expanded = True
@@ -145,9 +149,12 @@ class TaskCard(Vertical):
         self.expanded = False
 
     def watch_expanded(self):
-        # Only toggle description visibility - single batch update
+        # Toggle focus-expanded content in one place.
         is_visible = self.app.config.task.always_expanded or self.expanded
         self.description.display = is_visible
+        self.metadata_label.display = (
+            self.app.config.task.metadata_always_expanded or self.expanded
+        )
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         if self.app.config.backend.mode == Backends.JIRA:

--- a/tests/app_tests/test_board_screen.py
+++ b/tests/app_tests/test_board_screen.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 from kanban_tui.app import KanbanTui
-from textual.widgets import Input, Button
+from textual.widgets import Input, Button, Label
 from kanban_tui.config import Backends, MovementModes
 from kanban_tui.screens.board_screen import BoardScreen
 from kanban_tui.widgets.board_widgets import KanbanBoard
@@ -45,6 +45,36 @@ async def test_kanbanboard_task_creation(no_task_app: KanbanTui):
         assert isinstance(pilot.app.screen, BoardScreen)
 
         assert len(list(pilot.app.screen.query(TaskCard).results())) == 1
+
+
+async def test_task_metadata_visible_by_default(test_app: KanbanTui):
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        assert pilot.app.config.task.metadata_always_expanded
+        metadata = pilot.app.focused.query_one(".label-metadata", Label)
+        assert metadata.display
+        assert "no due" in metadata.content.plain
+        assert "no dependencies" in metadata.content.plain
+
+
+async def test_task_metadata_hidden_until_focus_when_disabled(test_app: KanbanTui):
+    test_app.config.task.metadata_always_expanded = False
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        task_cards = list(pilot.app.screen.query(TaskCard).results())
+        first_card = task_cards[0]
+        second_card = task_cards[1]
+
+        first_metadata = first_card.query_one(".label-metadata", Label)
+        second_metadata = second_card.query_one(".label-metadata", Label)
+
+        assert first_metadata.display
+        assert not second_metadata.display
+
+        await pilot.press("j")
+
+        assert not first_metadata.display
+        assert second_metadata.display
+        assert "no due" in second_metadata.content.plain
+        assert "no dependencies" in second_metadata.content.plain
 
 
 async def test_kanbanboard_board_view(no_task_app: KanbanTui):

--- a/tests/app_tests/test_settings_screen.py
+++ b/tests/app_tests/test_settings_screen.py
@@ -60,6 +60,25 @@ async def test_task_expand_switch(test_app: KanbanTui):
         assert pilot.app.needs_refresh
 
 
+async def test_task_metadata_expand_switch(test_app: KanbanTui):
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        await pilot.press("ctrl+l")
+        await pilot.pause()
+
+        assert pilot.app.config.task.metadata_always_expanded
+        assert pilot.app.screen.query_exactly_one(
+            "#switch_expand_metadata", Switch
+        ).value
+        assert pilot.app.needs_refresh
+
+        await pilot.click("#switch_expand_metadata")
+        assert not pilot.app.screen.query_exactly_one(
+            "#switch_expand_metadata", Switch
+        ).value
+        assert not pilot.app.config.task.metadata_always_expanded
+        assert pilot.app.needs_refresh
+
+
 async def test_task_movement_mode(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         await pilot.press("ctrl+l")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,7 @@ def test_default_config(test_config: Settings, test_database_path: str) -> None:
         "task": {
             "always_expanded": False,
             "default_color": "#004578",
+            "metadata_always_expanded": True,
             "movement_mode": "adjacent",
         },
         "backend": {


### PR DESCRIPTION
👋 I've started using your excellent Kanban tool to keep track of some agentic work.  I have not been using the due date or task dependencies, so all of my cards say `😎 no due ✅ no dependencies` which can take up a significant amount of space and doesn't give me any value.

So here I introduced a new setting that aligns to the "Always Expand Tasks" setting to "Always Show Metadata."  I defaulted it to Yes so that it doesn't break any existing flows.

Before:
<img width="753" height="529" alt="image" src="https://github.com/user-attachments/assets/b84933d4-6bdc-48b5-93dc-eab666bf4c1c" />

After:
<img width="747" height="549" alt="image" src="https://github.com/user-attachments/assets/ea140c4e-8712-4196-9409-e40d75dc2c98" />

Setting:
<img width="746" height="93" alt="image" src="https://github.com/user-attachments/assets/200a4c44-70fa-4a39-8e3e-5a108c822eeb" />

