### PR TITLE
feat: add configurable board auto refresh

### DIFF
--- a/src/kanban_tui/app.py
+++ b/src/kanban_tui/app.py
@@ -6,6 +6,7 @@ from textual import on, work
 from textual.app import App
 from textual.binding import Binding
 from textual.reactive import reactive
+from textual.timer import Timer
 from textual.widgets import Select
 
 from kanban_tui.modal.modal_auth_screen import ModalAuthScreen
@@ -71,6 +72,7 @@ class KanbanTui(App[str | None]):
         self.demo_mode = demo_mode
         self.auth_only = auth_only
         self.backend = self.get_backend()
+        self.auto_refresh_timer: Timer | None = None
 
     def get_backend(self):
         match self.config.backend.mode:
@@ -93,8 +95,8 @@ class KanbanTui(App[str | None]):
 
     @work()
     async def on_mount(self) -> None:
-        # self.set_interval(10, self.action_refresh)
         self.theme = self.config.board.theme
+        self.configure_auto_refresh()
 
         if self.auth_only:
             await self.show_auth_screen_only()
@@ -228,6 +230,23 @@ class KanbanTui(App[str | None]):
 
     def action_show_backend_selector(self):
         self.screen.query_one(KanbanTuiFooter).toggle_show()
+
+    def configure_auto_refresh(self) -> None:
+        if self.auto_refresh_timer is not None:
+            self.auto_refresh_timer.stop()
+            self.auto_refresh_timer = None
+
+        interval = self.config.board.auto_refresh_interval
+        if interval <= 0:
+            return
+
+        self.auto_refresh_timer = self.set_interval(
+            interval, self.handle_auto_refresh_tick
+        )
+
+    def handle_auto_refresh_tick(self) -> None:
+        if isinstance(self.screen, BoardScreen) and not self.needs_refresh:
+            self.action_refresh()
 
     def action_refresh(self):
         self.update_board_list()

--- a/src/kanban_tui/config.py
+++ b/src/kanban_tui/config.py
@@ -34,6 +34,7 @@ class MovementModes(StrEnum):
 class BoardSettings(BaseModel):
     theme: str = Field(default="dracula")
     columns_in_view: int = Field(default=3)
+    auto_refresh_interval: int = Field(default=0)
 
 
 class TaskSettings(BaseModel):
@@ -89,6 +90,10 @@ class Settings(BaseSettings):
 
     def set_theme(self, new_theme: str) -> None:
         self.board.theme = new_theme
+        self.save()
+
+    def set_auto_refresh_interval(self, new_interval: int) -> None:
+        self.board.auto_refresh_interval = new_interval
         self.save()
 
     def set_task_always_expanded(self, new_value: bool) -> None:

--- a/src/kanban_tui/screens/settings_screen.py
+++ b/src/kanban_tui/screens/settings_screen.py
@@ -27,6 +27,7 @@ class SettingsScreen(Screen):
                 "switch_expand_tasks": "e",
                 "switch_expand_metadata": "m",
                 "select_columns_in_view": "b",
+                "select_auto_refresh_interval": "a",
                 "task_color_preview": "g",
                 "select_movement_mode": "n",
                 "select_reset": "s",

--- a/src/kanban_tui/widgets/settings_widgets.py
+++ b/src/kanban_tui/widgets/settings_widgets.py
@@ -110,6 +110,37 @@ class BoardColumnsInView(Horizontal):
                 select.value = self.app.config.board.columns_in_view
 
 
+class BoardAutoRefreshSelector(Horizontal):
+    app: "KanbanTui"
+    OPTIONS = [
+        ("Off", 0),
+        ("15s", 15),
+        ("30s", 30),
+        ("1m", 60),
+        ("5m", 300),
+    ]
+
+    def on_mount(self):
+        self.border_title = "board.auto_refresh_interval"
+
+    def compose(self) -> Iterable[Widget]:
+        yield Label("Auto Refresh")
+        with self.prevent(Select.Changed):
+            auto_refresh_select = VimSelect(
+                self.OPTIONS,
+                value=self.app.config.board.auto_refresh_interval,
+                id="select_auto_refresh_interval",
+                allow_blank=False,
+            )
+            auto_refresh_select.jump_mode = "focus"
+            yield auto_refresh_select
+
+    @on(Select.Changed)
+    def update_config(self, event: Select.Changed):
+        self.app.config.set_auto_refresh_interval(event.value)
+        self.app.configure_auto_refresh()
+
+
 class TaskAlwaysExpandedSwitch(Horizontal):
     app: "KanbanTui"
 
@@ -661,10 +692,11 @@ class SettingsView(Vertical):
             yield TaskAlwaysExpandedSwitch(classes="setting-block")
             yield TaskMetadataAlwaysExpandedSwitch(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
-            yield TaskMovementSelector(classes="setting-block")
             yield TaskDefaultColorSelector(classes="setting-block")
+            yield TaskMovementSelector(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
             yield BoardColumnsInView(classes="setting-block")
+            yield BoardAutoRefreshSelector(classes="setting-block")
         with Horizontal(classes="setting-horizontal"):
             yield StatusColumnSelector(classes="setting-block")
             yield ColumnSelector(classes="setting-block")

--- a/tests/app_tests/test_app.py
+++ b/tests/app_tests/test_app.py
@@ -115,6 +115,50 @@ async def test_app_refresh(
         assert len(pilot.app.task_list) == 4
 
 
+async def test_app_auto_refresh_updates_board(test_app: KanbanTui):
+    test_app.config.board.auto_refresh_interval = 15
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        pilot.app.backend.delete_task(task_id=1)
+        assert len(pilot.app.task_list) == 5
+
+        pilot.app.handle_auto_refresh_tick()
+        assert len(pilot.app.task_list) == 4
+
+
+async def test_app_auto_refresh_noop_off_board(test_app: KanbanTui):
+    test_app.config.board.auto_refresh_interval = 15
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        await pilot.press("ctrl+l")
+        await pilot.pause()
+
+        pilot.app.backend.delete_task(task_id=1)
+        pilot.app.handle_auto_refresh_tick()
+        assert len(pilot.app.task_list) == 5
+
+        await pilot.press("ctrl+j")
+        pilot.app.handle_auto_refresh_tick()
+        assert len(pilot.app.task_list) == 4
+
+
+async def test_app_auto_refresh_timer_reconfigured(test_app: KanbanTui):
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        pilot.app.config.board.auto_refresh_interval = 15
+        pilot.app.configure_auto_refresh()
+        first_timer = pilot.app.auto_refresh_timer
+
+        pilot.app.config.board.auto_refresh_interval = 30
+        pilot.app.configure_auto_refresh()
+        second_timer = pilot.app.auto_refresh_timer
+
+        assert first_timer is not None
+        assert second_timer is not None
+        assert first_timer is not second_timer
+
+        pilot.app.config.board.auto_refresh_interval = 0
+        pilot.app.configure_auto_refresh()
+        assert pilot.app.auto_refresh_timer is None
+
+
 async def test_app_auth_only(test_app: KanbanTui):
     test_app.auth_only = True
     test_app.config.backend.mode = Backends.JIRA

--- a/tests/app_tests/test_settings_screen.py
+++ b/tests/app_tests/test_settings_screen.py
@@ -154,6 +154,35 @@ async def test_board_columns_in_view(test_app: KanbanTui):
         assert pilot.app.screen.query_one(KanbanBoard).scrollbars_enabled[1]
 
 
+async def test_board_auto_refresh_interval(test_app: KanbanTui):
+    async with test_app.run_test(size=APP_SIZE) as pilot:
+        await pilot.press("ctrl+l")
+        await pilot.pause()
+
+        assert pilot.app.config.board.auto_refresh_interval == 0
+        assert (
+            pilot.app.screen.query_exactly_one(
+                "#select_auto_refresh_interval", Select
+            ).value
+            == 0
+        )
+        assert pilot.app.auto_refresh_timer is None
+
+        await pilot.click("#select_auto_refresh_interval")
+        await pilot.press("down")
+        await pilot.press("enter")
+
+        assert pilot.app.config.board.auto_refresh_interval == 15
+        assert (
+            pilot.app.screen.query_exactly_one(
+                "#select_auto_refresh_interval", Select
+            ).value
+            == 15
+        )
+        assert pilot.app.auto_refresh_timer is not None
+        assert pilot.app.needs_refresh
+
+
 async def test_column_selector(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         await pilot.press("ctrl+l")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,14 @@ def test_config_theme_update(test_config: Settings) -> None:
     assert updated_config.board.theme == "monokai"
 
 
+def test_config_auto_refresh_interval_update(test_config: Settings) -> None:
+    test_config.set_auto_refresh_interval(60)
+    assert test_config.board.auto_refresh_interval == 60
+
+    updated_config = Settings()
+    assert updated_config.board.auto_refresh_interval == 60
+
+
 def test_config_creation(
     test_config: Settings,
     test_config_path: str,
@@ -68,6 +76,7 @@ def test_default_config(test_config: Settings, test_database_path: str) -> None:
         "board": {
             "theme": "dracula",
             "columns_in_view": 3,
+            "auto_refresh_interval": 0,
         },
         "task": {
             "always_expanded": False,


### PR DESCRIPTION
I'm using the CLI and some skills to interact with kanban-tui.  I noticed that when the CLI runs to make changes, the UI doesn't refresh.  There was some commented out code about a previous refresh setup.  So I turned it into a setting where you can pick the frequency.  Default is set to 0 (so it doesn't change behavior).

<img width="750" height="547" alt="image" src="https://github.com/user-attachments/assets/452487d3-2697-4d66-910b-ab5a6765af2a" />
