### PR TITLE
Replace pilot.app with typed app fixtures in test assertions

### DIFF
--- a/tests/app_tests/test_app.py
+++ b/tests/app_tests/test_app.py
@@ -15,9 +15,9 @@ async def test_empty_app(
     empty_app: KanbanTui, test_config_path: str, test_database_path: str
 ):
     async with empty_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 0
-        assert len(pilot.app.board_list) == 0
-        assert isinstance(pilot.app.screen, ModalBoardOverviewScreen)
+        assert len(empty_app.task_list) == 0
+        assert len(empty_app.board_list) == 0
+        assert isinstance(empty_app.screen, ModalBoardOverviewScreen)
 
         assert Path(test_database_path).exists()
         assert Path(test_config_path).exists()
@@ -27,8 +27,8 @@ async def test_no_task_app(
     no_task_app: KanbanTui, test_config_path: str, test_database_path: str
 ):
     async with no_task_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 0
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert len(no_task_app.task_list) == 0
+        assert isinstance(no_task_app.screen, BoardScreen)
 
         assert Path(test_database_path).exists()
         assert Path(test_config_path).exists()
@@ -36,8 +36,8 @@ async def test_no_task_app(
 
 async def test_app(test_app: KanbanTui, test_config_path: str, test_database_path: str):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 5
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert len(test_app.task_list) == 5
+        assert isinstance(test_app.screen, BoardScreen)
 
         assert Path(test_database_path).exists()
         assert Path(test_config_path).exists()
@@ -45,7 +45,7 @@ async def test_app(test_app: KanbanTui, test_config_path: str, test_database_pat
 
 async def test_app_no_visible_tasks(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 5
+        assert len(test_app.task_list) == 5
 
         # delete only task in doing column
         await pilot.press("l")
@@ -64,65 +64,65 @@ async def test_app_no_visible_tasks(test_app: KanbanTui):
         await pilot.press("space")
         await pilot.press("ctrl+j")
 
-        assert isinstance(pilot.app.focused, KanbanBoard)
+        assert isinstance(test_app.focused, KanbanBoard)
 
 
 async def test_app_properties(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 5
+        assert len(test_app.task_list) == 5
 
-        assert pilot.app.visible_column_dict == {1: "Ready", 2: "Doing", 3: "Done"}
+        assert test_app.visible_column_dict == {1: "Ready", 2: "Doing", 3: "Done"}
 
-        assert not pilot.app.demo_mode
-        assert pilot.app.backend.active_board.board_id == 1
+        assert not test_app.demo_mode
+        assert test_app.backend.active_board.board_id == 1
 
-        assert not pilot.app.auth_only
+        assert not test_app.auth_only
 
 
 async def test_app_correct_backend_type(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert isinstance(pilot.app.backend, SqliteBackend)
+        assert isinstance(test_app.backend, SqliteBackend)
 
 
 async def test_app_correct_backend_settings(
     test_app: KanbanTui, test_database_path: str
 ):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert pilot.app.backend.settings.database_path == test_database_path
-        assert pilot.app.backend.settings.active_board_id == 1
+        assert test_app.backend.settings.database_path == test_database_path
+        assert test_app.backend.settings.active_board_id == 1
 
 
 async def test_app_backend_settings_change(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert pilot.app.backend.settings.active_board_id == 1
+        assert test_app.backend.settings.active_board_id == 1
 
         pilot.app.config.set_active_board(2)
-        assert pilot.app.backend.settings.active_board_id == 2
+        assert test_app.backend.settings.active_board_id == 2
 
 
 async def test_app_refresh(
     test_app: KanbanTui, test_config_path: str, test_database_path: str
 ):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 5
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert len(test_app.task_list) == 5
+        assert isinstance(test_app.screen, BoardScreen)
 
         pilot.app.backend.delete_task(task_id=1)
-        assert len(pilot.app.task_list) == 5
+        assert len(test_app.task_list) == 5
 
         # refresh app
         await pilot.press("r")
-        assert len(pilot.app.task_list) == 4
+        assert len(test_app.task_list) == 4
 
 
 async def test_app_auto_refresh_updates_board(test_app: KanbanTui):
     test_app.config.board.auto_refresh_interval = 15
     async with test_app.run_test(size=APP_SIZE) as pilot:
         pilot.app.backend.delete_task(task_id=1)
-        assert len(pilot.app.task_list) == 5
+        assert len(test_app.task_list) == 5
 
         pilot.app.handle_auto_refresh_tick()
-        assert len(pilot.app.task_list) == 4
+        assert len(test_app.task_list) == 4
 
 
 async def test_app_auto_refresh_noop_off_board(test_app: KanbanTui):
@@ -133,11 +133,11 @@ async def test_app_auto_refresh_noop_off_board(test_app: KanbanTui):
 
         pilot.app.backend.delete_task(task_id=1)
         pilot.app.handle_auto_refresh_tick()
-        assert len(pilot.app.task_list) == 5
+        assert len(test_app.task_list) == 5
 
         await pilot.press("ctrl+j")
         pilot.app.handle_auto_refresh_tick()
-        assert len(pilot.app.task_list) == 4
+        assert len(test_app.task_list) == 4
 
 
 async def test_app_auto_refresh_timer_reconfigured(test_app: KanbanTui):
@@ -156,7 +156,7 @@ async def test_app_auto_refresh_timer_reconfigured(test_app: KanbanTui):
 
         pilot.app.config.board.auto_refresh_interval = 0
         pilot.app.configure_auto_refresh()
-        assert pilot.app.auto_refresh_timer is None
+        assert test_app.auto_refresh_timer is None
 
 
 async def test_app_refresh_ignored_while_refresh_pending(test_app: KanbanTui):
@@ -183,5 +183,5 @@ async def test_app_auth_only(test_app: KanbanTui):
     test_app.config.backend.mode = Backends.JIRA
     test_app.backend = test_app.get_backend()
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert pilot.app.auth_only
-        assert isinstance(pilot.app.screen, ModalAuthScreen)
+        assert test_app.auth_only
+        assert isinstance(test_app.screen, ModalAuthScreen)

--- a/tests/app_tests/test_board_screen.py
+++ b/tests/app_tests/test_board_screen.py
@@ -22,34 +22,34 @@ APP_SIZE = (150, 50)
 
 async def test_no_task_kanbanboard(no_task_app: KanbanTui):
     async with no_task_app.run_test(size=APP_SIZE) as pilot:
-        assert len(pilot.app.task_list) == 0
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert len(no_task_app.task_list) == 0
+        assert isinstance(no_task_app.screen, BoardScreen)
 
-        assert isinstance(pilot.app.focused, KanbanBoard)
+        assert isinstance(no_task_app.focused, KanbanBoard)
 
 
 async def test_kanbanboard_task_creation(no_task_app: KanbanTui):
     async with no_task_app.run_test(size=APP_SIZE) as pilot:
         # open modal to create Task
         await pilot.press("n")
-        assert isinstance(pilot.app.screen, ModalTaskEditScreen)
-        assert pilot.app.focused.id == "input_title"
-        assert pilot.app.screen.query_one("#input_title", Input).value == ""
+        assert isinstance(no_task_app.screen, ModalTaskEditScreen)
+        assert no_task_app.focused.id == "input_title"
+        assert no_task_app.screen.query_one("#input_title", Input).value == ""
 
         # Enter new task name
         await pilot.press(*"Test Task")
-        assert pilot.app.screen.query_one("#input_title").value == "Test Task"
+        assert no_task_app.screen.query_one("#input_title").value == "Test Task"
 
         # save task
         await pilot.click("#btn_continue")
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert isinstance(no_task_app.screen, BoardScreen)
 
-        assert len(list(pilot.app.screen.query(TaskCard).results())) == 1
+        assert len(list(no_task_app.screen.query(TaskCard).results())) == 1
 
 
 async def test_task_metadata_visible_by_default(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert pilot.app.config.task.metadata_always_expanded
+        assert test_app.config.task.metadata_always_expanded
         metadata = pilot.app.focused.query_one(".label-metadata", Label)
         assert metadata.display
         assert "no due" in metadata.content.plain
@@ -81,190 +81,190 @@ async def test_kanbanboard_board_view(no_task_app: KanbanTui):
     async with no_task_app.run_test(size=APP_SIZE) as pilot:
         # open modal to show Boards
         await pilot.press("B")
-        assert isinstance(pilot.app.screen, ModalBoardOverviewScreen)
+        assert isinstance(no_task_app.screen, ModalBoardOverviewScreen)
 
         # Open Board Creation Screen
         await pilot.press("n")
-        assert isinstance(pilot.app.screen, ModalNewBoardScreen)
-        assert pilot.app.focused.id == "input_board_icon"
-        assert pilot.app.screen.query_one("#input_board_name", Input).value == ""
-        assert pilot.app.screen.query_one("#btn_continue_new_board", Button).disabled
+        assert isinstance(no_task_app.screen, ModalNewBoardScreen)
+        assert no_task_app.focused.id == "input_board_icon"
+        assert no_task_app.screen.query_one("#input_board_name", Input).value == ""
+        assert no_task_app.screen.query_one("#btn_continue_new_board", Button).disabled
 
         # Enter new board name
         await pilot.click("#input_board_name")
         await pilot.press(*"Test Board")
 
-        assert pilot.app.screen.query_one("#input_board_name").value == "Test Board"
-        assert not pilot.app.screen.query_one(
+        assert no_task_app.screen.query_one("#input_board_name").value == "Test Board"
+        assert not no_task_app.screen.query_one(
             "#btn_continue_new_board", Button
         ).disabled
 
         # save board
         await pilot.click("#btn_continue_new_board")
         await pilot.press("escape")
-        assert isinstance(pilot.app.screen, BoardScreen)
+        assert isinstance(no_task_app.screen, BoardScreen)
 
         # new Board no tasks
-        assert len(list(pilot.app.screen.query(TaskCard).results())) == 0
-        assert len(list(pilot.app.board_list)) == 2
+        assert len(list(no_task_app.screen.query(TaskCard).results())) == 0
+        assert len(list(no_task_app.board_list)) == 2
 
 
 # https://github.com/Zaloog/kanban-tui/issues/1
 async def test_kanbanboard_movement_no_task_app(no_task_app: KanbanTui):
     async with no_task_app.run_test(size=APP_SIZE) as pilot:
         # check if board has focus
-        assert isinstance(pilot.app.focused, KanbanBoard)
+        assert isinstance(no_task_app.focused, KanbanBoard)
 
         # if no card is present, should just return and dont do any movevemt
         await pilot.press("h")
 
-        assert isinstance(pilot.app.focused, KanbanBoard)
+        assert isinstance(no_task_app.focused, KanbanBoard)
 
 
 async def test_kanbanboard_movement(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         # 1st card is focused
         # 3 in ready, 1 in doing, 1 in done
-        assert isinstance(pilot.app.focused, TaskCard)
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert isinstance(test_app.focused, TaskCard)
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # up 0 -> 2
         await pilot.press("k")
-        assert pilot.app.focused.task_.title == "Task_ready_2"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 2
+        assert test_app.focused.task_.title == "Task_ready_2"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 2
 
         # up 2- > 1
         await pilot.press("k")
-        assert pilot.app.focused.task_.title == "Task_ready_1"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 1
+        assert test_app.focused.task_.title == "Task_ready_1"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 1
 
         # 2x down 1 -> 0
         await pilot.press("j", "j")
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # right ready -> doing
         await pilot.press("j")
         await pilot.press("l")
-        assert pilot.app.focused.task_.title == "Task_doing_0"
-        assert pilot.app.focused.task_.column == 2
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_doing_0"
+        assert test_app.focused.task_.column == 2
+        assert test_app.focused.row == 0
 
         # 2x right doing -> ready
         await pilot.press("l", "l")
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # left ready -> done
         await pilot.press("k")
         await pilot.press("h")
-        assert pilot.app.focused.task_.title == "Task_done_0"
-        assert pilot.app.focused.task_.column == 3
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_done_0"
+        assert test_app.focused.task_.column == 3
+        assert test_app.focused.row == 0
 
         # 2x left done -> ready
         await pilot.press("h", "h")
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # delete Done Task
         await pilot.press("l")
         await pilot.press("d")
         await pilot.click("#btn_continue")
-        assert pilot.app.focused.task_.title == "Task_ready_2"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 2
+        assert test_app.focused.task_.title == "Task_ready_2"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 2
 
         # move right skip done column
         await pilot.press("l")
-        assert pilot.app.focused.task_.title == "Task_done_0"
-        assert pilot.app.focused.task_.column == 3
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_done_0"
+        assert test_app.focused.task_.column == 3
+        assert test_app.focused.row == 0
 
         # move left skip done column
         await pilot.press("h")
-        assert pilot.app.focused.task_.title == "Task_ready_2"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 2
+        assert test_app.focused.task_.title == "Task_ready_2"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 2
 
 
 async def test_kanbanboard_card_movement_adjacent(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         # 1st card is focused
         # 3 in ready, 1 in doing, 1 in done
-        assert isinstance(pilot.app.focused, TaskCard)
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert isinstance(test_app.focused, TaskCard)
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # try move card left
         # ready -> ready
         await pilot.press("H")
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         await pilot.press("L")
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 2
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 2
+        assert test_app.focused.row == 0
 
         await pilot.press("h")
-        assert pilot.app.focused.task_.title == "Task_ready_1"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_1"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         await pilot.press("L")
-        assert pilot.app.focused.task_.title == "Task_ready_1"
-        assert pilot.app.focused.task_.column == 2
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_1"
+        assert test_app.focused.task_.column == 2
+        assert test_app.focused.row == 0
 
 
 async def test_kanbanboard_card_movement_jump(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         # 1st card is focused
         # 3 in ready, 1 in doing, 1 in done
-        assert isinstance(pilot.app.focused, TaskCard)
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert isinstance(test_app.focused, TaskCard)
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
         # change movement mode
         pilot.app.config.task.movement_mode = MovementModes.JUMP
         # try move card right twice
         # ready -> done
         await pilot.press("L")
-        assert pilot.app.screen.query_one(KanbanBoard).target_column == 2
+        assert test_app.screen.query_one(KanbanBoard).target_column == 2
 
         await pilot.press("L")
-        assert pilot.app.screen.query_one(KanbanBoard).target_column == 3
+        assert test_app.screen.query_one(KanbanBoard).target_column == 3
         await pilot.press("enter")
-        assert pilot.app.screen.query_one(KanbanBoard).target_column is None
+        assert test_app.screen.query_one(KanbanBoard).target_column is None
 
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 3
-        assert pilot.app.focused.row == 0
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 3
+        assert test_app.focused.row == 0
 
 
 async def test_kanbanboard_card_movement_mouse_same_column(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         # 1st card is focused
         # 3 in ready, 1 in doing, 1 in done
-        assert isinstance(pilot.app.focused, TaskCard)
+        assert isinstance(test_app.focused, TaskCard)
         await pilot.mouse_down(pilot.app.focused)
-        assert pilot.app.screen.query_one(KanbanBoard).mouse_down
+        assert test_app.screen.query_one(KanbanBoard).mouse_down
         await pilot.mouse_up(pilot.app.screen.query_one(Column))
-        assert not pilot.app.screen.query_one(KanbanBoard).mouse_down
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 1
-        assert pilot.app.focused.row == 0
+        assert not test_app.screen.query_one(KanbanBoard).mouse_down
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 1
+        assert test_app.focused.row == 0
 
 
 @pytest.mark.skipif(
@@ -274,13 +274,13 @@ async def test_kanbanboard_card_movement_mouse_different_column(test_app: Kanban
     async with test_app.run_test(size=APP_SIZE) as pilot:
         # 1st card is focused
         # 3 in ready, 1 in doing, 1 in done
-        assert isinstance(pilot.app.focused, TaskCard)
+        assert isinstance(test_app.focused, TaskCard)
         await pilot.mouse_down(pilot.app.focused)
-        assert pilot.app.screen.query_one(KanbanBoard).mouse_down
+        assert test_app.screen.query_one(KanbanBoard).mouse_down
         await pilot.mouse_up(pilot.app.screen.query(Column).last())
-        assert not pilot.app.screen.query_one(KanbanBoard).mouse_down
-        assert pilot.app.focused.task_.title == "Task_ready_0"
-        assert pilot.app.focused.task_.column == 3
+        assert not test_app.screen.query_one(KanbanBoard).mouse_down
+        assert test_app.focused.task_.title == "Task_ready_0"
+        assert test_app.focused.task_.column == 3
 
 
 async def test_kanbanboard_drag_cross_column_inserts_at_target_position(
@@ -288,8 +288,8 @@ async def test_kanbanboard_drag_cross_column_inserts_at_target_position(
 ):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         board = pilot.app.screen.query_one(KanbanBoard)
-        assert isinstance(pilot.app.focused, TaskCard)
-        assert pilot.app.focused.task_.title == "Task_ready_0"
+        assert isinstance(test_app.focused, TaskCard)
+        assert test_app.focused.task_.title == "Task_ready_0"
 
         board.selected_task = pilot.app.focused.task_
         board.mouse_down = True
@@ -465,24 +465,24 @@ async def test_sync_tasks_updates_same_ids_in_place(test_app: KanbanTui):
 async def test_refresh_keeps_focus_on_same_task(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
         await pilot.press("j")
-        assert isinstance(pilot.app.focused, TaskCard)
+        assert isinstance(test_app.focused, TaskCard)
         focused_before = pilot.app.focused.task_.task_id
 
         await pilot.press("r")
 
-        assert isinstance(pilot.app.focused, TaskCard)
-        assert pilot.app.focused.task_.task_id == focused_before
+        assert isinstance(test_app.focused, TaskCard)
+        assert test_app.focused.task_.task_id == focused_before
 
 
 async def test_custom_footer(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert not pilot.app.screen.query_one(VimSelect).display
+        assert not test_app.screen.query_one(VimSelect).display
 
         await pilot.press("C")
-        assert pilot.app.screen.query_one(VimSelect).display
+        assert test_app.screen.query_one(VimSelect).display
 
 
 async def test_custom_footer_backend_switcher(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert not pilot.app.screen.query_one(VimSelect).display
-        assert pilot.app.screen.query_one(VimSelect).value == f"✔  {Backends.SQLITE}"
+        assert not test_app.screen.query_one(VimSelect).display
+        assert test_app.screen.query_one(VimSelect).value == f"✔  {Backends.SQLITE}"

--- a/tests/app_tests/test_overview_screen.py
+++ b/tests/app_tests/test_overview_screen.py
@@ -12,12 +12,12 @@ async def test_overview_view_no_tasks(no_task_app: KanbanTui, test_database_path
         await pilot.press("ctrl+k")
         await pilot.pause()
 
-        assert isinstance(pilot.app.screen, OverViewScreen)
-        assert pilot.app.screen.query_one("#plot_widget").styles.width.value == 1
+        assert isinstance(no_task_app.screen, OverViewScreen)
+        assert no_task_app.screen.query_one("#plot_widget").styles.width.value == 1
 
         await pilot.press("L")
         # 1 board CREATE + 4 column CREATEs + 3 board UPDATEs (status columns) = 8
-        assert pilot.app.screen.query_one("#datatable_logs").row_count == 8
+        assert no_task_app.screen.query_one("#datatable_logs").row_count == 8
 
 
 async def test_overview_view(test_app: KanbanTui, test_database_path):
@@ -25,15 +25,15 @@ async def test_overview_view(test_app: KanbanTui, test_database_path):
         await pilot.press("ctrl+k")
         await pilot.pause()
 
-        assert isinstance(pilot.app.screen, OverViewScreen)
+        assert isinstance(test_app.screen, OverViewScreen)
         await pilot.press("P")
         assert (
-            pilot.app.screen.query_one("#tabbed_content_overview").active == "tab_plot"
+            test_app.screen.query_one("#tabbed_content_overview").active == "tab_plot"
         )
 
         await pilot.press("L")
         # 1 board + 4 columns + 3 status updates + 5 tasks = 13
-        assert pilot.app.screen.query_one("#datatable_logs").row_count == 13
+        assert test_app.screen.query_one("#datatable_logs").row_count == 13
 
 
 async def test_overview_tab_switch(test_app: KanbanTui, test_database_path):
@@ -43,17 +43,17 @@ async def test_overview_tab_switch(test_app: KanbanTui, test_database_path):
 
         # initial is log
         assert (
-            pilot.app.screen.query_one("#tabbed_content_overview").active == "tab_log"
+            test_app.screen.query_one("#tabbed_content_overview").active == "tab_log"
         )
         # switch to plot
         await pilot.press("P")
         assert (
-            pilot.app.screen.query_one("#tabbed_content_overview").active == "tab_plot"
+            test_app.screen.query_one("#tabbed_content_overview").active == "tab_plot"
         )
         # switch back to log
         await pilot.press("L")
         assert (
-            pilot.app.screen.query_one("#tabbed_content_overview").active == "tab_log"
+            test_app.screen.query_one("#tabbed_content_overview").active == "tab_log"
         )
 
 
@@ -63,13 +63,13 @@ async def test_overview_plot_filter_values(test_app: KanbanTui, test_database_pa
         await pilot.pause()
 
         await pilot.press("P")
-        assert not pilot.app.screen.query_one("#switch_plot_category_detail").value
+        assert not test_app.screen.query_one("#switch_plot_category_detail").value
         assert (
-            pilot.app.screen.query_one("#select_plot_filter_amount").value
+            test_app.screen.query_one("#select_plot_filter_amount").value
             == "start_date"
         )
         assert (
-            pilot.app.screen.query_one("#select_plot_filter_frequency").value == "month"
+            test_app.screen.query_one("#select_plot_filter_frequency").value == "month"
         )
 
 
@@ -92,11 +92,11 @@ async def test_overview_log_filter_values(
         await pilot.pause()
 
         await pilot.press("L")
-        assert pilot.app.screen.query_one("#datatable_logs").row_count == 13
+        assert test_app.screen.query_one("#datatable_logs").row_count == 13
 
         await pilot.click(
             list(pilot.app.screen.query(LogFilterButton).results())[button_no]
         )
         assert (
-            pilot.app.screen.query_one("#datatable_logs").row_count == log_rows_visible
+            test_app.screen.query_one("#datatable_logs").row_count == log_rows_visible
         )

--- a/tests/app_tests/test_settings_screen.py
+++ b/tests/app_tests/test_settings_screen.py
@@ -27,10 +27,10 @@ async def test_settings_view_empty(no_task_app: KanbanTui, test_database_path):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert isinstance(pilot.app.screen, SettingsScreen)
+        assert isinstance(no_task_app.screen, SettingsScreen)
         await pilot.click("#input_database_path")
-        assert isinstance(pilot.app.focused, Input)
-        assert pilot.app.focused.value == test_database_path
+        assert isinstance(no_task_app.focused, Input)
+        assert no_task_app.focused.value == test_database_path
 
 
 async def test_settings_view(test_app: KanbanTui, test_database_path):
@@ -38,10 +38,10 @@ async def test_settings_view(test_app: KanbanTui, test_database_path):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert isinstance(pilot.app.screen, SettingsScreen)
+        assert isinstance(test_app.screen, SettingsScreen)
         await pilot.click("#input_database_path")
-        assert isinstance(pilot.app.focused, Input)
-        assert pilot.app.focused.value == test_database_path
+        assert isinstance(test_app.focused, Input)
+        assert test_app.focused.value == test_database_path
 
 
 async def test_task_expand_switch(test_app: KanbanTui):
@@ -49,17 +49,17 @@ async def test_task_expand_switch(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert not pilot.app.config.task.always_expanded
-        assert not pilot.app.screen.query_exactly_one(
+        assert not test_app.config.task.always_expanded
+        assert not test_app.screen.query_exactly_one(
             "#switch_expand_tasks", Switch
         ).value
-        assert pilot.app.needs_refresh
+        assert test_app.needs_refresh
 
         # toggle Switch
         await pilot.click("#switch_expand_tasks")
-        assert pilot.app.screen.query_exactly_one("#switch_expand_tasks", Switch).value
-        assert pilot.app.config.task.always_expanded
-        assert pilot.app.needs_refresh
+        assert test_app.screen.query_exactly_one("#switch_expand_tasks", Switch).value
+        assert test_app.config.task.always_expanded
+        assert test_app.needs_refresh
 
 
 async def test_task_metadata_expand_switch(test_app: KanbanTui):
@@ -67,18 +67,18 @@ async def test_task_metadata_expand_switch(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.config.task.metadata_always_expanded
-        assert pilot.app.screen.query_exactly_one(
+        assert test_app.config.task.metadata_always_expanded
+        assert test_app.screen.query_exactly_one(
             "#switch_expand_metadata", Switch
         ).value
-        assert pilot.app.needs_refresh
+        assert test_app.needs_refresh
 
         await pilot.click("#switch_expand_metadata")
-        assert not pilot.app.screen.query_exactly_one(
+        assert not test_app.screen.query_exactly_one(
             "#switch_expand_metadata", Switch
         ).value
-        assert not pilot.app.config.task.metadata_always_expanded
-        assert pilot.app.needs_refresh
+        assert not test_app.config.task.metadata_always_expanded
+        assert test_app.needs_refresh
 
 
 async def test_task_metadata_expand_switch_refreshes_board_cards(test_app: KanbanTui):
@@ -90,7 +90,7 @@ async def test_task_metadata_expand_switch_refreshes_board_cards(test_app: Kanba
         await pilot.pause()
         await pilot.click("#switch_expand_metadata")
 
-        assert not pilot.app.config.task.metadata_always_expanded
+        assert not test_app.config.task.metadata_always_expanded
 
         await pilot.press("ctrl+j")
         await pilot.pause()
@@ -104,9 +104,9 @@ async def test_task_movement_mode(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.config.task.movement_mode == MovementModes.ADJACENT
+        assert test_app.config.task.movement_mode == MovementModes.ADJACENT
         assert (
-            pilot.app.screen.query_exactly_one("#select_movement_mode", Select).value
+            test_app.screen.query_exactly_one("#select_movement_mode", Select).value
             == MovementModes.ADJACENT
         )
 
@@ -114,12 +114,12 @@ async def test_task_movement_mode(test_app: KanbanTui):
         await pilot.click("#select_movement_mode")
         await pilot.press("down")
         await pilot.press("enter")
-        assert pilot.app.config.task.movement_mode == MovementModes.JUMP
+        assert test_app.config.task.movement_mode == MovementModes.JUMP
         assert (
-            pilot.app.screen.query_exactly_one("#select_movement_mode", Select).value
+            test_app.screen.query_exactly_one("#select_movement_mode", Select).value
             == MovementModes.JUMP
         )
-        assert pilot.app.needs_refresh
+        assert test_app.needs_refresh
 
 
 async def test_task_append_mode(test_app: KanbanTui):
@@ -133,21 +133,21 @@ async def test_task_append_mode(test_app: KanbanTui):
             "Controls where tasks are inserted when moved across columns."
         )
 
-        assert pilot.app.config.task.append_mode == TaskAppendModes.TOP
+        assert test_app.config.task.append_mode == TaskAppendModes.TOP
         assert (
-            pilot.app.screen.query_exactly_one("#select_append_mode", Select).value
+            test_app.screen.query_exactly_one("#select_append_mode", Select).value
             == TaskAppendModes.TOP
         )
 
         await pilot.click("#select_append_mode")
         await pilot.press("down")
         await pilot.press("enter")
-        assert pilot.app.config.task.append_mode == TaskAppendModes.BOTTOM
+        assert test_app.config.task.append_mode == TaskAppendModes.BOTTOM
         assert (
-            pilot.app.screen.query_exactly_one("#select_append_mode", Select).value
+            test_app.screen.query_exactly_one("#select_append_mode", Select).value
             == TaskAppendModes.BOTTOM
         )
-        assert pilot.app.needs_refresh
+        assert test_app.needs_refresh
 
 
 async def test_backend_mode(test_app: KanbanTui):
@@ -155,9 +155,9 @@ async def test_backend_mode(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.config.backend.mode == Backends.SQLITE
+        assert test_app.config.backend.mode == Backends.SQLITE
         assert (
-            pilot.app.screen.query_exactly_one("#select_backend_mode", Select).value
+            test_app.screen.query_exactly_one("#select_backend_mode", Select).value
             == f"✔  {Backends.SQLITE}"
         )
 
@@ -166,22 +166,22 @@ async def test_backend_mode(test_app: KanbanTui):
         await pilot.press("down")
         await pilot.press("enter")
         # TODO Change in Future
-        assert pilot.app.config.backend.mode == Backends.SQLITE
+        assert test_app.config.backend.mode == Backends.SQLITE
         assert (
-            pilot.app.screen.query_exactly_one("#select_backend_mode", Select).value
+            test_app.screen.query_exactly_one("#select_backend_mode", Select).value
             == f"✔  {Backends.SQLITE}"
         )
 
 
 async def test_board_columns_in_view(test_app: KanbanTui):
     async with test_app.run_test(size=APP_SIZE) as pilot:
-        assert not pilot.app.screen.query_one(KanbanBoard).scrollbars_enabled[1]
+        assert not test_app.screen.query_one(KanbanBoard).scrollbars_enabled[1]
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.config.board.columns_in_view == 3
+        assert test_app.config.board.columns_in_view == 3
         assert (
-            pilot.app.screen.query_exactly_one("#select_columns_in_view", Select).value
+            test_app.screen.query_exactly_one("#select_columns_in_view", Select).value
             == 3
         )
 
@@ -189,17 +189,17 @@ async def test_board_columns_in_view(test_app: KanbanTui):
         await pilot.click("#select_columns_in_view")
         await pilot.press("up")
         await pilot.press("enter")
-        assert pilot.app.config.board.columns_in_view == 2
+        assert test_app.config.board.columns_in_view == 2
         assert (
-            pilot.app.screen.query_exactly_one("#select_columns_in_view", Select).value
+            test_app.screen.query_exactly_one("#select_columns_in_view", Select).value
             == 2
         )
-        assert pilot.app.needs_refresh
+        assert test_app.needs_refresh
 
         # check columns in view
         await pilot.press("ctrl+j")
         await pilot.pause()
-        assert pilot.app.screen.query_one(KanbanBoard).scrollbars_enabled[1]
+        assert test_app.screen.query_one(KanbanBoard).scrollbars_enabled[1]
 
 
 async def test_board_auto_refresh_interval(test_app: KanbanTui):
@@ -207,28 +207,28 @@ async def test_board_auto_refresh_interval(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.config.board.auto_refresh_interval == 0
+        assert test_app.config.board.auto_refresh_interval == 0
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 "#select_auto_refresh_interval", Select
             ).value
             == 0
         )
-        assert pilot.app.auto_refresh_timer is None
+        assert test_app.auto_refresh_timer is None
 
         await pilot.click("#select_auto_refresh_interval")
         await pilot.press("down")
         await pilot.press("enter")
 
-        assert pilot.app.config.board.auto_refresh_interval == 15
+        assert test_app.config.board.auto_refresh_interval == 15
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 "#select_auto_refresh_interval", Select
             ).value
             == 15
         )
-        assert pilot.app.auto_refresh_timer is not None
-        assert pilot.app.needs_refresh
+        assert test_app.auto_refresh_timer is not None
+        assert test_app.needs_refresh
 
 
 async def test_column_selector(test_app: KanbanTui):
@@ -239,7 +239,7 @@ async def test_column_selector(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
 
 async def test_column_selector_navigation(test_app: KanbanTui):
@@ -250,15 +250,15 @@ async def test_column_selector_navigation(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Go to Ready Item
         await pilot.press("j")
-        assert isinstance(pilot.app.focused, ColumnSelector)
-        assert pilot.app.focused.highlighted_child.id == "listitem_column_1"
+        assert isinstance(test_app.focused, ColumnSelector)
+        assert test_app.focused.highlighted_child.id == "listitem_column_1"
 
         await pilot.press(*"jj")
-        assert pilot.app.focused.highlighted_child.id == "listitem_column_3"
+        assert test_app.focused.highlighted_child.id == "listitem_column_3"
 
 
 async def test_column_visibility(test_app: KanbanTui):
@@ -269,25 +269,25 @@ async def test_column_visibility(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Go to Ready ColumnItem
         await pilot.press("j")
-        assert isinstance(pilot.app.focused, ColumnSelector)
-        assert pilot.app.focused.highlighted_child.id == "listitem_column_1"
+        assert isinstance(test_app.focused, ColumnSelector)
+        assert test_app.focused.highlighted_child.id == "listitem_column_1"
 
         # toggle visibility
         await pilot.press("space")
         await pilot.pause()
-        assert pilot.app.visible_column_dict == {2: "Doing", 3: "Done"}
+        assert test_app.visible_column_dict == {2: "Doing", 3: "Done"}
 
         # Go to Archive ColumnItem
         await pilot.press(*"jjj")
-        assert pilot.app.focused.highlighted_child.id == "listitem_column_4"
+        assert test_app.focused.highlighted_child.id == "listitem_column_4"
 
         await pilot.press("space")
         await pilot.pause()
-        assert pilot.app.visible_column_dict == {2: "Doing", 3: "Done", 4: "Archive"}
+        assert test_app.visible_column_dict == {2: "Doing", 3: "Done", 4: "Archive"}
 
 
 async def test_column_delete_press(no_task_app: KanbanTui):
@@ -298,18 +298,18 @@ async def test_column_delete_press(no_task_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(no_task_app.focused, ColumnSelector)
 
         # Go to Ready Item
         await pilot.press("j")
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(no_task_app.focused, ColumnSelector)
         # Delete Column
         await pilot.press("d")
-        assert isinstance(pilot.app.screen, ModalConfirmScreen)
+        assert isinstance(no_task_app.screen, ModalConfirmScreen)
         await pilot.press("enter")
-        assert isinstance(pilot.app.screen, SettingsScreen)
-        assert len(pilot.app.column_list) == 3
-        assert pilot.app.visible_column_dict == {2: "Doing", 3: "Done"}
+        assert isinstance(no_task_app.screen, SettingsScreen)
+        assert len(no_task_app.column_list) == 3
+        assert no_task_app.visible_column_dict == {2: "Doing", 3: "Done"}
 
 
 async def test_column_delete_click(no_task_app: KanbanTui):
@@ -320,19 +320,19 @@ async def test_column_delete_click(no_task_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(no_task_app.focused, ColumnSelector)
 
         # Go to Ready Item
         await pilot.press("j")
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(no_task_app.focused, ColumnSelector)
         # Delete Column
         await pilot.press("d")
-        assert isinstance(pilot.app.screen, ModalConfirmScreen)
+        assert isinstance(no_task_app.screen, ModalConfirmScreen)
         await pilot.click("#btn_continue")
         await pilot.pause()
-        assert isinstance(pilot.app.screen, SettingsScreen)
-        assert len(pilot.app.column_list) == 3
-        assert pilot.app.visible_column_dict == {2: "Doing", 3: "Done"}
+        assert isinstance(no_task_app.screen, SettingsScreen)
+        assert len(no_task_app.column_list) == 3
+        assert no_task_app.visible_column_dict == {2: "Doing", 3: "Done"}
 
 
 @pytest.mark.parametrize(
@@ -353,18 +353,18 @@ async def test_column_creation(
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         await pilot.click(
             pilot.app.screen.query(AddRule)[position].query_exactly_one(Button)
         )
-        assert isinstance(pilot.app.screen, ModalUpdateColumnScreen)
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
 
         await pilot.press(*column_name)
         await pilot.click("#btn_continue")
         await pilot.pause()
 
-        assert pilot.app.visible_column_dict == visible_column_dict
+        assert test_app.visible_column_dict == visible_column_dict
 
 
 async def test_column_creation_cancel_press(test_app: KanbanTui):
@@ -375,15 +375,15 @@ async def test_column_creation_cancel_press(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Click on First Position
         await pilot.click(pilot.app.screen.query(AddRule)[0].query_exactly_one(Button))
-        assert isinstance(pilot.app.screen, ModalUpdateColumnScreen)
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
 
         # Cancel Modal View
         await pilot.press("escape")
-        assert isinstance(pilot.app.screen, SettingsScreen)
+        assert isinstance(test_app.screen, SettingsScreen)
 
 
 async def test_column_creation_cancel_click(test_app: KanbanTui):
@@ -394,17 +394,17 @@ async def test_column_creation_cancel_click(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Click on First Position
         await pilot.click(pilot.app.screen.query(AddRule)[0].query_exactly_one(Button))
         await pilot.pause()
-        assert isinstance(pilot.app.screen, ModalUpdateColumnScreen)
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
 
         # Cancel Modal View
         await pilot.click("#btn_cancel")
         await pilot.pause()
-        assert isinstance(pilot.app.screen, SettingsScreen)
+        assert isinstance(test_app.screen, SettingsScreen)
 
 
 async def test_column_creation_column_name_present(test_app: KanbanTui):
@@ -415,15 +415,15 @@ async def test_column_creation_column_name_present(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Click on First Position
         await pilot.click(pilot.app.screen.query(AddRule)[0].query_exactly_one(Button))
-        assert isinstance(pilot.app.screen, ModalUpdateColumnScreen)
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
 
         # Cancel Modal View
         await pilot.press(*"Ready")
-        assert pilot.app.screen.query_exactly_one("#btn_continue").disabled
+        assert test_app.screen.query_exactly_one("#btn_continue").disabled
 
 
 async def test_column_rename(test_app: KanbanTui):
@@ -434,32 +434,32 @@ async def test_column_rename(test_app: KanbanTui):
         # await pilot.press("shift+tab")
         pilot.app.screen.query_exactly_one(ColumnSelector).focus()
         await pilot.pause()
-        assert isinstance(pilot.app.focused, ColumnSelector)
+        assert isinstance(test_app.focused, ColumnSelector)
 
         # Navigate to First ColumnListItem
         await pilot.press("j")
-        assert pilot.app.focused.highlighted_child.column.name == "Ready"
+        assert test_app.focused.highlighted_child.column.name == "Ready"
 
         # Rename
         await pilot.press("r")
-        assert isinstance(pilot.app.screen, ModalUpdateColumnScreen)
-        assert pilot.app.focused.placeholder == "Current column name: 'Ready'"
-        assert pilot.app.focused.value == ""
-        assert pilot.app.screen.query_exactly_one("#btn_continue").disabled
+        assert isinstance(test_app.screen, ModalUpdateColumnScreen)
+        assert test_app.focused.placeholder == "Current column name: 'Ready'"
+        assert test_app.focused.value == ""
+        assert test_app.screen.query_exactly_one("#btn_continue").disabled
 
         await pilot.press("r")
         await pilot.press("backspace")
-        assert pilot.app.screen.query_exactly_one("#btn_continue").disabled
+        assert test_app.screen.query_exactly_one("#btn_continue").disabled
 
         await pilot.press(*"New Name!")
         await pilot.click("#btn_continue")
         await pilot.pause()
-        assert pilot.app.focused.highlighted_child.column.name == "New Name!"
-        assert pilot.app.column_list[0].name == "New Name!"
+        assert test_app.focused.highlighted_child.column.name == "New Name!"
+        assert test_app.column_list[0].name == "New Name!"
 
         await pilot.press("ctrl+j")
         await pilot.pause()
-        assert pilot.app.screen.query_one("#column_1").title == "New Name!"
+        assert test_app.screen.query_one("#column_1").title == "New Name!"
 
 
 # Test for https://github.com/Zaloog/kanban-tui/issues/113
@@ -484,7 +484,7 @@ async def test_column_rename_columns_in_view_bug(test_app: KanbanTui):
         await pilot.press(*"New Name!")
         await pilot.click("#btn_continue")
         await pilot.pause()
-        assert pilot.app.focused.highlighted_child.column.name == "New Name!"
+        assert test_app.focused.highlighted_child.column.name == "New Name!"
         assert test_app.screen.query_exactly_one("#select_columns_in_view").value == 3
 
 
@@ -493,12 +493,12 @@ async def test_setting_shortcuts(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.screen.query_exactly_one(DataBasePathInput).has_focus_within
+        assert test_app.screen.query_exactly_one(DataBasePathInput).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("e")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(
+        assert test_app.screen.query_exactly_one(
             TaskAlwaysExpandedSwitch
         ).has_focus_within
 
@@ -509,31 +509,31 @@ async def test_setting_shortcuts(test_app: KanbanTui):
         await pilot.press("ctrl+o")
         await pilot.press("c")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(ColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(ColumnSelector).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("n")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(TaskMovementSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(TaskMovementSelector).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("p")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(
+        assert test_app.screen.query_exactly_one(
             TaskAppendModeSelector
         ).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("g")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(
+        assert test_app.screen.query_exactly_one(
             TaskDefaultColorSelector
         ).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("s")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
 
 
 async def test_status_column_selector(test_app: KanbanTui):
@@ -541,15 +541,15 @@ async def test_status_column_selector(test_app: KanbanTui):
         await pilot.press("ctrl+l")
         await pilot.pause()
 
-        assert pilot.app.screen.query_exactly_one(DataBasePathInput).has_focus_within
+        assert test_app.screen.query_exactly_one(DataBasePathInput).has_focus_within
 
         await pilot.press("ctrl+o")
         await pilot.press("s")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
 
         # reset_column is now pre-populated with column 1 (Ready)
-        assert pilot.app.focused.value == 1
+        assert test_app.focused.value == 1
 
         await pilot.click(pilot.app.focused)
         await pilot.press(*"jj")  # Navigate down 2 positions
@@ -557,14 +557,14 @@ async def test_status_column_selector(test_app: KanbanTui):
         await pilot.pause()
 
         # After pressing jj from column 1, we should be at column 3 (Done)
-        assert pilot.app.focused.value == 3
-        assert pilot.app.active_board.reset_column == 3
+        assert test_app.focused.value == 3
+        assert test_app.active_board.reset_column == 3
 
         await pilot.click(pilot.app.screen.query_one("#select_start"))
         await pilot.press("enter")
         await pilot.pause()
-        assert pilot.app.active_board.reset_column == 3
-        assert pilot.app.active_board.start_column == 2
+        assert test_app.active_board.reset_column == 3
+        assert test_app.active_board.start_column == 2
 
 
 async def test_status_update_task_in_start_column(test_app: KanbanTui):
@@ -575,11 +575,11 @@ async def test_status_update_task_in_start_column(test_app: KanbanTui):
         await pilot.press("ctrl+o")
         await pilot.press("s")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(StatusColumnSelector).has_focus_within
         # Go to Start Select
         await pilot.press("j")
         # start_column is now pre-populated with column 2 (Doing)
-        assert pilot.app.focused.value == 2
+        assert test_app.focused.value == 2
 
         # Select Doing (column 2)
         await pilot.press("enter")
@@ -589,7 +589,7 @@ async def test_status_update_task_in_start_column(test_app: KanbanTui):
         await pilot.pause()
 
         # assert pilot.app.focused.value == 2
-        assert pilot.app.active_board.start_column == 1
+        assert test_app.active_board.start_column == 1
 
         # go to finish select
         await pilot.press("j")
@@ -597,13 +597,13 @@ async def test_status_update_task_in_start_column(test_app: KanbanTui):
         await pilot.press("k")
         await pilot.press("enter")
         await pilot.pause()
-        assert pilot.app.active_board.finish_column == 2
+        assert test_app.active_board.finish_column == 2
 
         await pilot.press("ctrl+j")
         await pilot.pause()
         await pilot.press("L")
         assert (
-            pilot.app.focused.task_.creation_date == pilot.app.focused.task_.start_date
+            test_app.focused.task_.creation_date == test_app.focused.task_.start_date
         )
 
 
@@ -615,18 +615,18 @@ async def test_column_position_change_down(test_app: KanbanTui):
         await pilot.press("ctrl+o")
         await pilot.press("c")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(ColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(ColumnSelector).has_focus_within
 
         await pilot.press("j")
 
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.name
             == "Ready"
         )
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.position
             == 1
@@ -636,13 +636,13 @@ async def test_column_position_change_down(test_app: KanbanTui):
         await pilot.press("J")
         await pilot.pause()
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.name
             == "Ready"
         )
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.position
             == 2
@@ -657,19 +657,19 @@ async def test_column_position_change_up(test_app: KanbanTui):
         await pilot.press("ctrl+o")
         await pilot.press("c")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(ColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(ColumnSelector).has_focus_within
 
         # Go to Doing Item
         await pilot.press(*"jj")
 
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.name
             == "Doing"
         )
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.position
             == 2
@@ -679,13 +679,13 @@ async def test_column_position_change_up(test_app: KanbanTui):
         await pilot.press("K")
         await pilot.pause()
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.name
             == "Doing"
         )
         assert (
-            pilot.app.screen.query_exactly_one(
+            test_app.screen.query_exactly_one(
                 ColumnSelector
             ).highlighted_child.column.position
             == 1
@@ -701,7 +701,7 @@ async def test_column_position_change_updates_status_values(test_app: KanbanTui)
         await pilot.press("ctrl+o")
         await pilot.press("c")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(ColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(ColumnSelector).has_focus_within
 
         # Go to Doing Item
         await pilot.press(*"jj")
@@ -713,7 +713,7 @@ async def test_column_position_change_updates_status_values(test_app: KanbanTui)
         # get Dropdown value at position 1, which should be "Doing at this point"
         assert (
             (
-                pilot.app.screen.query_exactly_one(StatusColumnSelector)
+                test_app.screen.query_exactly_one(StatusColumnSelector)
                 .query_one("#select_reset", Select)
                 ._options[1][0]
                 ._text[0]
@@ -782,12 +782,12 @@ async def test_column_selector_updates_on_board_change(test_app: KanbanTui):
         await pilot.pause()
         await pilot.press("c")
         await pilot.pause()
-        assert pilot.app.screen.query_exactly_one(ColumnSelector).has_focus_within
+        assert test_app.screen.query_exactly_one(ColumnSelector).has_focus_within
 
         # Go to test_column2
         await pilot.press("j")
         await pilot.pause()
-        assert pilot.app.focused.highlighted_child.column.name == "test_column2"
+        assert test_app.focused.highlighted_child.column.name == "test_column2"
 
         # Columns in View also updates
-        assert pilot.app.screen.query_one("#select_columns_in_view").value == 1
+        assert test_app.screen.query_one("#select_columns_in_view").value == 1


### PR DESCRIPTION
## Context

While looking through the test suite to understand how `kanban-tui` structures its Textual app tests, I noticed the typing warnings mentioned in #63. The `pilot.app` property returns a generic `App` type, so type checkers (mypy, pyright) can't see `KanbanTui`-specific attributes like `task_list`, `board_list`, `config`, or `needs_refresh` — each access produces a warning.

## What this changes

In all four test files under `tests/app_tests/`, every `pilot.app` reference **inside an `assert` statement** is replaced with the corresponding typed fixture (`test_app`, `no_task_app`, `empty_app`, etc.). Since those fixtures are already annotated as `KanbanTui`, the type checker now resolves every attribute correctly.

Interaction calls — `pilot.press()`, `pilot.click()`, and widget `.focus()` invocations — still go through the `Pilot` object, because they need the `Pilot` API rather than the app type.

## Scope

- `test_app.py` — 30 replacements
- `test_board_screen.py` — 102 replacements
- `test_overview_screen.py` — 14 replacements
- `test_settings_screen.py` — 127 replacements

No logic or behavior changes; only the object used for attribute access in assertions is swapped.

Closes #63